### PR TITLE
~Optionally~ use <pre> (or any element) with specific id instead of <noscript>

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 3. Write some [markdown](https://guides.github.com/features/mastering-markdown/)
 ```
 <!-- my-page.html --> 
-<script src="https://rawcdn.githack.com/oscarmorrison/md-page/master/md-page.js"></script><noscript>
+<script src="https://rawcdn.githack.com/oscarmorrison/md-page/master/md-page.js"></script><pre id="md-page-markdown-text">
 
 # Header
 Welcome to my simplest site

--- a/docs/custom_style.md
+++ b/docs/custom_style.md
@@ -8,7 +8,7 @@ You can create a `.css` file and then include the layout of your preference. To 
 ---
 ```
 <link href="custom.css" rel="stylesheet"></link>
-<script src="https://rawcdn.githack.com/oscarmorrison/md-page/master/md-page.js"></script><noscript>
+<script src="https://rawcdn.githack.com/oscarmorrison/md-page/master/md-page.js"></script><pre id="md-page-markdown-text">
 
 # Header
 Welcome to md-page, the easiest way to make a webpage from just markdown...

--- a/docs/custom_title.md
+++ b/docs/custom_title.md
@@ -9,7 +9,7 @@ You can manually set a page title using the HTML (`<title> `) tag to define the 
 3. Write some markdown including the `<title>` tag
 
 ```
-<script src="https://rawcdn.githack.com/oscarmorrison/md-page/master/md-page.js"></script><noscript>
+<script src="https://rawcdn.githack.com/oscarmorrison/md-page/master/md-page.js"></script><pre id="md-page-markdown-text">
 
 <title>Hello World</title>
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <script src="https://livejs.com/live.js"></script>
 <script src="src/showdown.js"></script>
-<script src="src/script.js"></script><noscript>
+<script src="src/script.js"></script><pre id="md-page-markdown-text">
 
 # header one
 

--- a/src/script.js
+++ b/src/script.js
@@ -64,14 +64,14 @@ document.addEventListener("DOMContentLoaded", function() {
     var isIE = window.navigator.userAgent.indexOf("MSIE ")
     if (isIE) {
         // https://stackoverflow.com/questions/656605/jquery-text-call-preserves-newlines-in-firefox-but-not-in-ie
-        var cloned = document.querySelector('noscript')
+        var cloned = document.querySelector('noscript, #md-page-markdown-text')
         var pre = document.createElement("pre") // IE11 will preserve formatting from pre or textarea
         pre.appendChild(cloned)
         var markdown = pre.textContent ? pre.textContent: pre.innerText;
         delete cloned
         delete pre
     } else {
-        var markdown = document.querySelector('noscript').innerText
+        var markdown = document.querySelector('noscript, #md-page-markdown-text').innerText
     }
 
     var converter = new showdown.Converter({


### PR DESCRIPTION
Blank page is shown if javascript is enabled but md-page script fails to load
for some reason (for example if the linked script is unavailable).
This happens because html isnt generated when md-page.js fails and
browsers won't show the fallback `<noscript>` content if JS is enabled.

`<noscript>` content is also seen garbled in browsers as
formatting including newlines and multiple spaces is ignored in html.

By using `<pre>` instead, we can guarantee display of md content and also
that formatting is preserved. An md-page specific element id can be used
to indicate exactly which element to parse.
For backwards compatibility `<noscript>` tag is also allowed.
The first match found of either an element with id="md-page-markdown-text"
or `<noscript>` will be used.

Co-Authored-By: harsgak <harsgak@users.noreply.github.com>