### PR TITLE
Fixes tests and part of the CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - review
+  workflow_dispatch:
 
 jobs:
   build:
@@ -21,10 +22,15 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install, test, and build
-      run: |
-        npm install
-        npm test
-        npm run build
+    - name: install
+      run: npm install
+      env:
+        CI: true
+    - name: build
+      run: npm run build
+      env:
+        CI: true
+    - name: test
+      run: npm run test-ci
       env:
         CI: true

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -11,17 +11,19 @@ Checkout from `review` branch. `master` is considered production branch and shou
 $ npm install
 ```
 
-## Run Tests
-```
-$ npm test
-```
-
 ## Build
 builds `md-page.js` at project root.
 
 (DO NOT SUBMIT THE BUILT FILE, REMOVE IT BEFORE OPENING PR)
 ```
 $ npm run build
+```
+
+## Run Tests
+At the moment, tests focus only on the build artifact. Thus, run `npm run build` before running any test.
+
+```
+$ npm test
 ```
 
 ## Opening PR

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "test": "jest --watchAll",
+    "test-ci": "jest",
     "build": "uglifyjs -c -m -o md-page.js src/showdown.js src/script.js -b beautify=false,ascii_only=true"
   },
   "repository": {

--- a/test/script.test.js
+++ b/test/script.test.js
@@ -1,5 +1,5 @@
 const { JSDOM } = require('jsdom');
-const baseHtml = '<script src="file://./md-page.js"></script><noscript>'
+const baseHtml = `<script src="file://${__dirname}/../md-page.js"></script><noscript>`
 const options = { resources: 'usable', runScripts: 'dangerously' };
 
 describe("HTML Rendering Tests: Ensures header syntax renders accurately.", () => {


### PR DESCRIPTION
This should fix #60

- Introduces the `test-ci` command for npm, removing the --watchAll options that caused the pipeline to hang
- Splits the test pipeline commands, thus they can be easily inspected
- Inside the test.yml, it performs the build before the test, because tests DEPEND ON the md-page artifact
- Adds `workflow_dispatch` for the test pipeline
- Updates the DEV\_README

We should, however, discuss the point of the --watchAll if we are testing the build artifact. Should we test (at least on dev) the script itself directly, or should we discourage the --watchAll?

Let me know